### PR TITLE
fix: resolve NoSuchMethodError for Android 14 and below compatibility

### DIFF
--- a/PluginCore/src/main/java/dev/mooner/starlight/plugincore/logger/ProjectLogger.kt
+++ b/PluginCore/src/main/java/dev/mooner/starlight/plugincore/logger/ProjectLogger.kt
@@ -129,7 +129,7 @@ class ProjectLogger private constructor(
         if (data.type != LogType.DEBUG) {
             synchronized(_logs) {
                 if (_logs.size > LOGS_MAX_SIZE)
-                    _logs.removeFirst()
+                    _logs.removeAt(0)
                 _logs += data
                 flush()
             }


### PR DESCRIPTION
 - fix: replace List.removeFirst() with removeAt(0) for Android compatibility
 - Resolve NoSuchMethodError occurring on Android 14 and below devices by replacing List.removeFirst() with removeAt(0) in ProjectLogger.kt.

 - Related: #54, #56, https://jakewharton.com/kotlins-jdk-release-compatibility-flag/